### PR TITLE
Add '--in-place' option for "kpm wrap"

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Commands/WrapCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Commands/WrapCommand.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Framework.PackageManager
             string targetProjectJson;
             if (InPlace)
             {
-                targetProjectJson = Path.Combine(projectDir, "project.json");
+                targetProjectJson = Path.Combine(projectDir, Runtime.Project.ProjectFileName);
             }
             else
             {

--- a/src/Microsoft.Framework.PackageManager/Commands/WrapCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Commands/WrapCommand.cs
@@ -293,6 +293,7 @@ namespace Microsoft.Framework.PackageManager
                 Reports.Information.WriteLine("  Adding project dependency '{0}.{1}'",
                     assemblyProjectName, WrapperProjectVersion);
                 AddProjectDependency(projectJson, assemblyProjectName, targetFramework);
+                AddWrapFolderToGlobalJson(rootDir);
             }
 
             PathUtility.EnsureParentDirectory(targetProjectJson);

--- a/src/Microsoft.Framework.PackageManager/Commands/WrapCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Commands/WrapCommand.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Framework.PackageManager
         public string CsProjectPath { get; set; }
         public string Configuration { get; set; }
         public string MsBuildPath { get; set; }
+        public bool InPlace { get; set; }
         public Reports Reports { get; set; }
 
         public bool ExecuteCommand()
@@ -226,12 +227,21 @@ namespace Microsoft.Framework.PackageManager
             var projectDir = Path.GetDirectoryName(projectFile);
             var rootDir = ProjectResolver.ResolveRootDirectory(projectDir);
             var wrapRoot = Path.Combine(rootDir, "wrap");
-            var projectResolver = new ProjectResolver(projectDir, rootDir);
-            var targetProjectJson = LocateExistingProject(projectResolver, projectName);
-            if (string.IsNullOrEmpty(targetProjectJson))
+
+            string targetProjectJson;
+            if (InPlace)
             {
-                AddWrapFolderToGlobalJson(rootDir);
-                targetProjectJson = Path.Combine(wrapRoot, projectName, Runtime.Project.ProjectFileName);
+                targetProjectJson = Path.Combine(projectDir, "project.json");
+            }
+            else
+            {
+                var projectResolver = new ProjectResolver(projectDir, rootDir);
+                targetProjectJson = LocateExistingProject(projectResolver, projectName);
+                if (string.IsNullOrEmpty(targetProjectJson))
+                {
+                    AddWrapFolderToGlobalJson(rootDir);
+                    targetProjectJson = Path.Combine(wrapRoot, projectName, Runtime.Project.ProjectFileName);
+                }
             }
 
             var targetFramework = GetTargetFramework(projectElement);

--- a/src/Microsoft.Framework.PackageManager/Microsoft.Framework.PackageManager.kproj
+++ b/src/Microsoft.Framework.PackageManager/Microsoft.Framework.PackageManager.kproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -15,6 +15,9 @@
     <DevelopmentServerPort>0</DevelopmentServerPort>
     <CommandLineArguments>help</CommandLineArguments>
     <DebugTarget>kpm</DebugTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Microsoft.Framework.PackageManager/Microsoft.Framework.PackageManager.kproj
+++ b/src/Microsoft.Framework.PackageManager/Microsoft.Framework.PackageManager.kproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -15,9 +15,6 @@
     <DevelopmentServerPort>0</DevelopmentServerPort>
     <CommandLineArguments>help</CommandLineArguments>
     <DebugTarget>kpm</DebugTarget>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Microsoft.Framework.PackageManager/Program.cs
+++ b/src/Microsoft.Framework.PackageManager/Program.cs
@@ -380,6 +380,9 @@ namespace Microsoft.Framework.PackageManager
                     var optMsBuildPath = c.Option("--msbuild <PATH>",
                         @"Path to MSBuild, default is '%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe'",
                         CommandOptionType.SingleValue);
+                    var optInPlace = c.Option("-i|--in-place",
+                        "Generate or update project.json files in project directories of csprojs",
+                        CommandOptionType.NoValue);
                     c.HelpOption("-?|-h|--help");
 
                     c.OnExecute(() =>
@@ -391,6 +394,7 @@ namespace Microsoft.Framework.PackageManager
                         command.CsProjectPath = argPath.Value;
                         command.Configuration = optConfiguration.Value();
                         command.MsBuildPath = optMsBuildPath.Value();
+                        command.InPlace = optInPlace.HasValue();
 
                         var success = command.ExecuteCommand();
 


### PR DESCRIPTION
parent #964 

Functional tests for `kpm wrap --in-place` will be added after #956 is merged.