### PR TITLE
fixed the issue when PackManager gets runtime path which ends with a slash

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Framework.PackageManager.Packing
 
             foreach (var runtime in _options.Runtimes)
             {
-                var frameworkName = DependencyContext.GetFrameworkNameForRuntime(Path.GetFileName(runtime));
+                var frameworkName = DependencyContext.GetFrameworkNameForRuntime(new DirectoryInfo(runtime).Name);
                 var runtimeLocated = TryAddRuntime(root, frameworkName, runtime);
                 List<string> runtimeProbePaths = null;
 


### PR DESCRIPTION
Fix #1005 .  Use DirectoryInfo class to parse runtime name from path.