### PR TITLE
Fix ServicingTable on mono

### DIFF
--- a/src/Microsoft.Framework.Runtime/Servicing/ServicingTable.cs
+++ b/src/Microsoft.Framework.Runtime/Servicing/ServicingTable.cs
@@ -38,6 +38,12 @@ namespace Microsoft.Framework.Runtime.Servicing
                         Environment.GetEnvironmentVariable("PROGRAMFILES");
                     }
 
+                    if (string.IsNullOrEmpty(servicingRoot))
+                    {
+                        // Nothing to do, no variables are set. Just return the uninitialized index.
+                        return index;
+                    }
+
                     dotnetServicing = Path.Combine(
                         servicingRoot,
                         "dotnet",

--- a/src/Microsoft.Framework.Runtime/Servicing/ServicingTable.cs
+++ b/src/Microsoft.Framework.Runtime/Servicing/ServicingTable.cs
@@ -40,13 +40,13 @@ namespace Microsoft.Framework.Runtime.Servicing
 
                     if (string.IsNullOrEmpty(servicingRoot))
                     {
-                        // Nothing to do, no variables are set. Just return the uninitialized index.
+                        // Nothing to do, we don't have Program Files. Just return the uninitialized index.
                         return index;
                     }
 
                     dotnetServicing = Path.Combine(
                         servicingRoot,
-                        "dotnet",
+                        "Microsoft .NET Cross-Platform SDK",
                         "Servicing");
                 }
 


### PR DESCRIPTION
/cc @lodejard @ChengTian @davidfowl - Specifically: Is it OK to leave ServicingIndex uninitialized? As far as I can tell, yes. It just acts like an empty index.

For now, we don't provide a "default" value for Linux. When we have one, we could add it here, but until then the null value is causing dotnet-mono to crash on startup.