### PR TITLE
Fixing preprocess code failing to load a class library

### DIFF
--- a/src/Microsoft.Framework.Runtime.Loader/LoadContext.cs
+++ b/src/Microsoft.Framework.Runtime.Loader/LoadContext.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+#if ASPNET50
+using System.Linq;
+#endif
 #if ASPNETCORE50
 using System.Runtime.Loader;
 #endif
@@ -224,10 +227,30 @@ namespace Microsoft.Framework.Runtime.Loader
                     return null;
                 }
 
-                if (args.RequestingAssembly != null)
+                var requestingAssembly = args.RequestingAssembly;
+
+#if ASPNET50
+                // On Mono while loading the !preprocess assembly the ResolveEventArgs.RequestingAssembly is not populated. 
+                // As a result when code in !preprocess references a class library the load fails on the class library.
+                // Below is a work around to try populate the requesting assembly.
+
+                if (Microsoft.Framework.Runtime.PlatformHelper.IsMono &&
+                    requestingAssembly == null &&
+                    !assemblyName.Name.Contains("!"))
+                {
+                    // See if this loading is for !preprocess.
+                    var domain = (AppDomain)sender;
+
+                    requestingAssembly = domain.GetAssemblies()
+                        .Reverse()
+                        .FirstOrDefault(a => a.FullName.Contains("!preprocess"));
+                }
+#endif
+
+                if (requestingAssembly != null)
                 {
                     // Get the relevant load context for the requesting assembly
-                    var loadContext = LoadContextAccessor.Instance.GetLoadContext(args.RequestingAssembly);
+                    var loadContext = LoadContextAccessor.Instance.GetLoadContext(requestingAssembly);
                     if (loadContext != null && loadContext != this && loadContext != Default)
                     {
                         return loadContext.Load(assemblyName.Name);
@@ -240,7 +263,8 @@ namespace Microsoft.Framework.Runtime.Loader
 
         private class DefaultLoadContext : LoadContext
         {
-            public DefaultLoadContext() : base(defaultContext: null)
+            public DefaultLoadContext()
+                : base(defaultContext: null)
             {
                 _contextId = null;
             }

--- a/src/Microsoft.Framework.Runtime.Loader/LoadContext.cs
+++ b/src/Microsoft.Framework.Runtime.Loader/LoadContext.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Framework.Runtime.Loader
 
                 if (Microsoft.Framework.Runtime.PlatformHelper.IsMono &&
                     requestingAssembly == null &&
-                    !assemblyName.Name.Contains("!"))
+                    !assemblyName.Name.Contains("!preprocess"))
                 {
                     // See if this loading is for !preprocess.
                     var domain = (AppDomain)sender;

--- a/src/Microsoft.Framework.Runtime.Loader/project.json
+++ b/src/Microsoft.Framework.Runtime.Loader/project.json
@@ -4,10 +4,10 @@
     "dependencies": {
         "Microsoft.Framework.Runtime.Interfaces": { "version": "1.0.0-*", "type": "build" }
     },
-
     "frameworks": {
         "aspnet50": {
             "dependencies": {
+                "Microsoft.Framework.Runtime.Common": ""
             }
         },
         "aspnetcore50": {
@@ -20,7 +20,6 @@
             }
         }
     },
-
     "scripts": {
         "postbuild": [
             "%project:Directory%/../../build/batchcopy %project:BuildOutputDir%/Debug/aspnet50/*.* %project:Directory%/../../artifacts/build/dotnet-clr-win-x86/bin",


### PR DESCRIPTION
This fixes bug : https://github.com/aspnet/XRE/issues/1048

On Mono while loading the !preprocess assembly the ResolveEventArgs.RequestingAssembly is not populated.
As a result when code in !preprocess references a class library the load fails on the class library.
Below is a work around to try populate the requesting assembly.

/CC @davidfowl 