### PR TITLE
Fix loaded module name in trace info

### DIFF
--- a/src/klr/klr.cpp
+++ b/src/klr/klr.cpp
@@ -297,7 +297,7 @@ int CallFirmwareProcessMain(int argc, wchar_t* argv[])
     DWORD dwFullAppBase = GetFullPathNameW(data.applicationBase, MAX_PATH, szFullAppBase, nullptr);
     if (!dwFullAppBase)
     {
-        ::wprintf_s(L"Failed to get full path of application base: %S\r\n", data.applicationBase);
+        ::wprintf_s(L"Failed to get full path of application base: %s\r\n", data.applicationBase);
         exitCode = 1;
         goto Finished;
     }
@@ -313,18 +313,18 @@ int CallFirmwareProcessMain(int argc, wchar_t* argv[])
     if (!m_hHostModule)
     {
         if (m_fVerboseTrace)
-            ::wprintf_s(L"Failed to load: %S\r\n", pwzHostModuleName);
+            ::wprintf_s(L"Failed to load: %s\r\n", pwzHostModuleName);
         m_hHostModule = nullptr;
         goto Finished;
     }
     if (m_fVerboseTrace)
-        ::wprintf_s(L"Loaded Module: %S\r\n", pwzHostModuleName);
+        ::wprintf_s(L"Loaded Module: %s\r\n", pwzHostModuleName);
 
     pfnCallApplicationMain = (FnCallApplicationMain)::GetProcAddress(m_hHostModule, pszCallApplicationMainName);
     if (!pfnCallApplicationMain)
     {
         if (m_fVerboseTrace)
-            ::wprintf_s(L"Failed to find function %s in %S\n", pszCallApplicationMainName, pwzHostModuleName);
+            ::wprintf_s(L"Failed to find function %S in %s\n", pszCallApplicationMainName, pwzHostModuleName);
         fSuccess = false;
         goto Finished;
     }

--- a/src/kre.coreclr/kre.coreclr.cpp
+++ b/src/kre.coreclr/kre.coreclr.cpp
@@ -23,7 +23,7 @@ void GetModuleDirectory(HMODULE module, LPWSTR szPath)
     szPath[dirLength + 1] = '\0';
 }
 
-// Generate a list of trusted platform assembiles. 
+// Generate a list of trusted platform assemblies. 
 bool GetTrustedPlatformAssembliesList(WCHAR* szDirectory, bool bNative, LPWSTR pszTrustedPlatformAssemblies, size_t cchTrustedPlatformAssemblies)
 {
     bool ret = true;
@@ -32,7 +32,7 @@ bool GetTrustedPlatformAssembliesList(WCHAR* szDirectory, bool bNative, LPWSTR p
     size_t cTpaAssemblyNames = 0;
     LPWSTR* ppszTpaAssemblyNames = nullptr;
 
-    // Build the list of the tpa assemblie 
+    // Build the list of the tpa assemblies 
     CreateTpaBase(&ppszTpaAssemblyNames, &cTpaAssemblyNames, bNative);
 
     // Scan the directory to see if all the files in TPA list exist
@@ -498,8 +498,8 @@ extern "C" __declspec(dllexport) HRESULT __stdcall CallApplicationMain(PCALL_APP
 
     if (FAILED(hr))
     {
-        wprintf_s(L"TPA      %d %S\n", wcslen(pwszTrustedPlatformAssemblies), pwszTrustedPlatformAssemblies);
-        wprintf_s(L"AppPaths %S\n", wszAppPaths);
+        wprintf_s(L"TPA      %d %s\n", wcslen(pwszTrustedPlatformAssemblies), pwszTrustedPlatformAssemblies);
+        wprintf_s(L"AppPaths %s\n", wszAppPaths);
         printf_s("Failed to create app domain (%x).\n", hr);
         return hr;
     }


### PR DESCRIPTION
parent #1164 
After upgrade of C++ compiler, the name of loaded module in KRE_TRACE info becomes incomplete. Seems the new C++ compiler is using a different spec for wide-char string formatted output.