### PR TITLE
ProjectResolver to look only for global.json

### DIFF
--- a/src/Microsoft.Framework.Runtime/ProjectResolver.cs
+++ b/src/Microsoft.Framework.Runtime/ProjectResolver.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Framework.Runtime
 
             return false;
         }
-        
+
         private IEnumerable<string> ResolveSearchPaths(string projectPath, string rootPath)
         {
             var paths = new List<string>
@@ -69,8 +69,8 @@ namespace Microsoft.Framework.Runtime
 
             while (di.Parent != null)
             {
-                if (di.EnumerateFiles(GlobalSettings.GlobalFileName).Any() ||
-                    di.EnumerateFiles("*.sln").Any())
+                var candidate = Path.Combine(di.FullName, GlobalSettings.GlobalFileName);
+                if (File.Exists(candidate))
                 {
                     return di.FullName;
                 }


### PR DESCRIPTION
Fixes : https://github.com/aspnet/XRE/issues/1153

Currently it looks for both a global.json and .sln file. With this change any projects without
a global.json file but only a .sln file will break.

@davidfowl 