### PR TITLE
Removed regex parsing from runtime framework parsing

### DIFF
--- a/src/kre.coreclr/tpa.cpp
+++ b/src/kre.coreclr/tpa.cpp
@@ -6,7 +6,7 @@
 
 BOOL CreateTpaBase(LPWSTR** ppNames, size_t* pcNames, bool bNative)
 {
-    const size_t count = 33;
+    const size_t count = 32;
     LPWSTR* pArray = new LPWSTR[count];
 
     if (bNative)
@@ -39,11 +39,10 @@ BOOL CreateTpaBase(LPWSTR** ppNames, size_t* pcNames, bool bNative)
         pArray[25] = _wcsdup(L"System.Runtime.Loader.ni.dll");
         pArray[26] = _wcsdup(L"System.Text.Encoding.ni.dll");
         pArray[27] = _wcsdup(L"System.Text.Encoding.Extensions.ni.dll");
-        pArray[28] = _wcsdup(L"System.Text.RegularExpressions.ni.dll");
-        pArray[29] = _wcsdup(L"System.Threading.ni.dll");
-        pArray[30] = _wcsdup(L"System.Threading.Overlapped.ni.dll");
-        pArray[31] = _wcsdup(L"System.Threading.Tasks.ni.dll");
-        pArray[32] = _wcsdup(L"System.Threading.ThreadPool.ni.dll");
+        pArray[28] = _wcsdup(L"System.Threading.ni.dll");
+        pArray[29] = _wcsdup(L"System.Threading.Overlapped.ni.dll");
+        pArray[30] = _wcsdup(L"System.Threading.Tasks.ni.dll");
+        pArray[31] = _wcsdup(L"System.Threading.ThreadPool.ni.dll");
     }
     else
     {
@@ -75,11 +74,10 @@ BOOL CreateTpaBase(LPWSTR** ppNames, size_t* pcNames, bool bNative)
         pArray[25] = _wcsdup(L"System.Runtime.Loader.dll");
         pArray[26] = _wcsdup(L"System.Text.Encoding.dll");
         pArray[27] = _wcsdup(L"System.Text.Encoding.Extensions.dll");
-        pArray[28] = _wcsdup(L"System.Text.RegularExpressions.dll");
-        pArray[29] = _wcsdup(L"System.Threading.dll");
-        pArray[30] = _wcsdup(L"System.Threading.Overlapped.dll");
-        pArray[31] = _wcsdup(L"System.Threading.Tasks.dll");
-        pArray[32] = _wcsdup(L"System.Threading.ThreadPool.dll");
+        pArray[28] = _wcsdup(L"System.Threading.dll");
+        pArray[29] = _wcsdup(L"System.Threading.Overlapped.dll");
+        pArray[30] = _wcsdup(L"System.Threading.Tasks.dll");
+        pArray[31] = _wcsdup(L"System.Threading.ThreadPool.dll");
     }
 
     *ppNames = pArray;

--- a/src/kre.host/FrameworkNameUtility.cs
+++ b/src/kre.host/FrameworkNameUtility.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Runtime.Versioning;
-using System.Text.RegularExpressions;
 
 namespace kre.host
 {
@@ -11,99 +10,16 @@ namespace kre.host
     {
         internal static FrameworkName ParseFrameworkName(string frameworkName)
         {
-            if (frameworkName == null)
+            if (frameworkName == "aspnet50")
             {
-                throw new ArgumentNullException("frameworkName");
+                return new FrameworkName("Asp.Net", new Version(5, 0));
+            }
+            else if (frameworkName == "aspnetcore50")
+            {
+                return new FrameworkName("Asp.NetCore", new Version(5, 0));
             }
 
-            // {Identifier}{Version}-{Profile}
-
-            // Split the framework name into 3 parts, identifier, version and profile.
-            string identifierPart = null;
-            string versionPart = null;
-
-            string[] parts = frameworkName.Split('-');
-
-            if (parts.Length > 2)
-            {
-                throw new ArgumentException("frameworkName");
-            }
-
-            string frameworkNameAndVersion = parts.Length > 0 ? parts[0].Trim() : null;
-            string profilePart = parts.Length > 1 ? parts[1].Trim() : null;
-
-            if (String.IsNullOrEmpty(frameworkNameAndVersion))
-            {
-                throw new ArgumentException("frameworkName");
-            }
-
-            // If we find a version then we try to split the framework name into 2 parts
-            var versionMatch = Regex.Match(frameworkNameAndVersion, @"\d+");
-
-            if (versionMatch.Success)
-            {
-                identifierPart = frameworkNameAndVersion.Substring(0, versionMatch.Index).Trim();
-                versionPart = frameworkNameAndVersion.Substring(versionMatch.Index).Trim();
-            }
-            else
-            {
-                // Otherwise we take the whole name as an identifier
-                identifierPart = frameworkNameAndVersion.Trim();
-            }
-
-            if (!String.IsNullOrEmpty(identifierPart))
-            {
-                if (identifierPart.Equals("aspnet", StringComparison.OrdinalIgnoreCase))
-                {
-                    identifierPart = "Asp.Net";
-                }
-                else if (identifierPart.Equals("aspnetcore", StringComparison.OrdinalIgnoreCase))
-                {
-                    identifierPart = "Asp.NetCore";
-                }
-                else if (identifierPart.Equals("k", StringComparison.OrdinalIgnoreCase))
-                {
-                    identifierPart = "Asp.NetCore";
-                }
-            }
-
-            Version version = null;
-            // We support version formats that are integers (40 becomes 4.0)
-            int versionNumber;
-            if (Int32.TryParse(versionPart, out versionNumber))
-            {
-                // Remove the extra numbers
-                if (versionPart.Length > 4)
-                {
-                    versionPart = versionPart.Substring(0, 4);
-                }
-
-                // Make sure it has at least 2 digits so it parses as a valid version
-                versionPart = versionPart.PadRight(2, '0');
-                versionPart = String.Join(".", versionPart.ToCharArray());
-            }
-
-            // If we can't parse the version then use the default
-            if (!Version.TryParse(versionPart, out version))
-            {
-                // We failed to parse the version string once more. So we need to decide if this is unsupported or if we use the default version.
-                // This framework is unsupported if:
-                // 1. The identifier part of the framework name is null.
-                // 2. The version part is not null.
-                if (String.IsNullOrEmpty(identifierPart) || !String.IsNullOrEmpty(versionPart))
-                {
-                    return null;
-                }
-
-                version = new Version(0, 0);
-            }
-
-            if (String.IsNullOrEmpty(identifierPart))
-            {
-                identifierPart = ".NETFramework";
-            }
-
-            return new FrameworkName(identifierPart, version, profilePart);
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/kre.host/LoaderContainer.cs
+++ b/src/kre.host/LoaderContainer.cs
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Framework.Runtime;
-using System.Diagnostics;
 
 namespace kre.host
 {

--- a/src/kre.host/project.json
+++ b/src/kre.host/project.json
@@ -20,14 +20,12 @@
                 "System.ComponentModel": "4.0.0-beta-*",
                 "System.Console": "4.0.0-beta-*",
                 "System.Diagnostics.Debug": "4.0.10-beta-*",
-                "System.IO.FileSystem": "4.0.0-beta-*",
                 "System.Linq": "4.0.0-beta-*",
                 "System.Reflection": "4.0.10-beta-*",
                 "System.Reflection.Extensions": "4.0.0-beta-*",
                 "System.Runtime": "4.0.20-beta-*",
                 "System.Runtime.Extensions": "4.0.10-beta-*",
                 "System.Runtime.InteropServices": "4.0.20-beta-*",
-                "System.Text.RegularExpressions": "4.0.10-beta-*",
                 "System.Threading": "4.0.10-beta-*",
                 "System.Threading.Tasks": "4.0.10-beta-*"
             }

--- a/src/kre.hosting.shared/project.json
+++ b/src/kre.hosting.shared/project.json
@@ -25,7 +25,6 @@
                 "System.Runtime.Extensions": "4.0.10-beta-*",
                 "System.Runtime.InteropServices": "4.0.20-beta-*",
                 "System.Runtime.Loader": "4.0.0-beta-*",
-                "System.Text.RegularExpressions": "4.0.10-beta-*",
                 "System.Threading": "4.0.10-beta-*",
                 "System.Threading.Tasks": "4.0.10-beta-*",
                 "System.Threading.ThreadPool": "4.0.10-beta-*"


### PR DESCRIPTION
- Just hard code the names that hosts should use (including casing).
- Verified Helios and console host uses those names