### PR TITLE
#2 : Low hanging fruit performance improvements from profiling session

### DIFF
--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/PackageIdValidator.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/PackageIdValidator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using System.Text.RegularExpressions;
 using NuGet.Resources;
 
 namespace NuGet
@@ -11,15 +10,49 @@ namespace NuGet
     public static class PackageIdValidator
     {
         internal const int MaxPackageIdLength = 100;
-        private static readonly Regex _idRegex = new Regex(@"^\w+([_.-]\w+)*$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
 
         public static bool IsValidPackageId(string packageId)
         {
-            if (packageId == null)
+            if (string.IsNullOrWhiteSpace(packageId))
             {
-                throw new ArgumentNullException("packageId");
+                throw new ArgumentException("packageId");
             }
-            return _idRegex.IsMatch(packageId);
+
+            // Rules: 
+            // Should start with a character
+            // Can be followed by '.' or '-'. Cannot have 2 of these special characters consecutively. 
+            // Cannot end with '-' or '.'
+
+            var firstChar = packageId[0];
+            if (!char.IsLetterOrDigit(firstChar) && firstChar != '_')
+            {
+                // Should start with a char/digit/_.
+                return false;
+            }
+
+            var lastChar = packageId[packageId.Length - 1];
+            if (lastChar == '-' || lastChar == '.')
+            {
+                // Should not end with a '-' or '.'.
+                return false;
+            }
+
+            for (int index = 1; index < packageId.Length - 1; index++)
+            {
+                var ch = packageId[index];
+                if (!char.IsLetterOrDigit(ch) || ch != '-' || ch != '.')
+                {
+                    return false;
+                }
+
+                if (ch == '-' || ch == '.' && ch == packageId[index - 1])
+                {
+                    // Cannot have two successive '-' or '.' in the name.
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public static void ValidatePackageId(string packageId)

--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
@@ -154,12 +154,17 @@ namespace NuGet
             }
 
             // If we find a version then we try to split the framework name into 2 parts
-            var versionMatch = Regex.Match(frameworkNameAndVersion, @"\d+");
-
-            if (versionMatch.Success)
+            int versionIndex = -1;
+            var versionMatch = frameworkNameAndVersion.FirstOrDefault(c =>
             {
-                identifierPart = frameworkNameAndVersion.Substring(0, versionMatch.Index).Trim();
-                versionPart = frameworkNameAndVersion.Substring(versionMatch.Index).Trim();
+                versionIndex++;
+                return char.IsDigit(c);
+            });
+
+            if (versionMatch != '\0' && versionIndex != -1)
+            {
+                identifierPart = frameworkNameAndVersion.Substring(0, versionIndex).Trim();
+                versionPart = frameworkNameAndVersion.Substring(versionIndex).Trim();
             }
             else
             {
@@ -699,8 +704,6 @@ namespace NuGet
 
             return hasItems;
         }
-
-
 
         internal static Version NormalizeVersion(Version verison)
         {


### PR DESCRIPTION
Bug #1147 
 
Addresses:
ResolvePackagePath reads sha512 files from the disk when it doesn't need to.
Regex use in SemanticVersion and VersionUtility.ParseFrameworkName should be removed. Regex has been replaced with regular string comparison in few more places. Now except PathResolver there are no more Regex usages in xre - that will probably be removed with new globbing.

Will plan to add a few unit tests with the next checkin. 

/CC @davidfowl 