### PR TITLE
Preparing for kpm packages add.

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -429,7 +429,16 @@ var RC_FILES = '${FindAllFiles("Resource.rc", BOOTSTRAPPER_EXE_NAME, BOOTSTRAPPE
     }
 
 #copy-coreclr
-    nuget-install package='CoreCLR' outputDir='packages' extra='-pre -nocache' once='CoreCLR' nugetPath='.nuget/nuget.exe'
+    @{
+        var extras = "-pre -nocache";
+        var coreCLRPackageSource = E("CORECLR_PACKAGE_SOURCE");
+        if (!string.IsNullOrEmpty(coreCLRPackageSource))
+        {
+            extras += " -source " + coreCLRPackageSource;
+        }
+    }
+
+    nuget-install package='CoreCLR' outputDir='packages' extra='${extras}' once='CoreCLR' nugetPath='.nuget/nuget.exe'
 
     var CoreCLR_DIR='${""}'
     @{


### PR DESCRIPTION
Changing the CI's volatile feed to use kpm packages add. However CoreCLR
is installed using nuget.exe and consequently requires specifying a flat
list to work correctly.