### PR TITLE
Fix an exception when a dependency in lock file has null version info

### DIFF
--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LockFileFormat.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LockFileFormat.cs
@@ -179,9 +179,10 @@ namespace Microsoft.Framework.Runtime.DependencyManagement
 
         private PackageDependency ReadPackageDependency(string property, JToken json)
         {
+            var versionStr = json.Value<string>();
             return new PackageDependency(
                 property,
-                VersionUtility.ParseVersionSpec(json.Value<string>()));
+                versionStr == null ? null : VersionUtility.ParseVersionSpec(versionStr));
         }
 
         private JProperty WritePackageDependency(PackageDependency item)


### PR DESCRIPTION
Lock file reader throws exception when `project.lock.json` contains null dependency info:
```json
"Serilog.Sinks.ElasticSearch/1.4.14": {
      "dependencySets": {
        "*": {
          "Serilog": null,
          "Elasticsearch.Net": "1.1.2"
        }
      },
      "contents": {
        "Serilog.Sinks.ElasticSearch.1.4.14.nupkg": {},
        "Serilog.Sinks.ElasticSearch.1.4.14.nupkg.sha512": {},
        "Serilog.Sinks.ElasticSearch.nuspec": {},
        "lib\\net40\\Serilog.Sinks.ElasticSearch.dll": {},
        "lib\\net40\\Serilog.Sinks.ElasticSearch.xml": {},
        "lib\\net45\\Serilog.Sinks.ElasticSearch.dll": {},
        "lib\\net45\\Serilog.Sinks.ElasticSearch.xml": {}
      }
    }
```