### PR TITLE
Kpm reacts to lockfile

### DIFF
--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LockFileFormat.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LockFileFormat.cs
@@ -92,6 +92,8 @@ namespace Microsoft.Framework.Runtime.DependencyManagement
             {
                 library.Version = SemanticVersion.Parse(parts[1]);
             }
+            // TODO: temporary null-tolerant operation. Need to change to ReadString() after CI pass.
+            library.Sha = json["sha"]?.ToString();
             library.DependencySets = ReadObject(json["dependencySets"] as JObject, ReadPackageDependencySet);
             library.FrameworkAssemblies = ReadFrameworkAssemblies(json["frameworkAssemblies"] as JObject);
             library.PackageAssemblyReferences = ReadArray(json["packageAssemblyReferences"] as JArray, ReadPackageReferenceSet);
@@ -102,6 +104,7 @@ namespace Microsoft.Framework.Runtime.DependencyManagement
         private JProperty WriteLibrary(LockFileLibrary library)
         {
             var json = new JObject();
+            json["sha"] = WriteString(library.Sha);
             WriteObject(json, "dependencySets", library.DependencySets, WritePackageDependencySet);
             WriteFrameworkAssemblies(json, "frameworkAssemblies", library.FrameworkAssemblies);
             WriteArray(json, "packageAssemblyReferences", library.PackageAssemblyReferences, WritePackageReferenceSet);

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LockFileLibrary.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LockFileLibrary.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Framework.Runtime.DependencyManagement
 
         public SemanticVersion Version { get; set; }
 
+        public string Sha { get; set; }
+
         public IList<PackageDependencySet> DependencySets { get; set; } = new List<PackageDependencySet>();
 
         public IList<FrameworkAssemblyReference> FrameworkAssemblies { get; set; } = new List<FrameworkAssemblyReference>();

--- a/src/Microsoft.Framework.Runtime/NuGet/Packages/PackageInfo.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Packages/PackageInfo.cs
@@ -8,7 +8,6 @@ namespace NuGet
     {
         private readonly IFileSystem _repositoryRoot;
         private readonly string _versionDir;
-        private readonly LockFileLibrary _lockFileLibrary;
         private IPackage _package;
 
         public PackageInfo(
@@ -22,12 +21,14 @@ namespace NuGet
             Id = packageId;
             Version = version;
             _versionDir = versionDir;
-            _lockFileLibrary = lockFileLibrary;
+            LockFileLibrary = lockFileLibrary;
         }
 
         public string Id { get; private set; }
 
         public SemanticVersion Version { get; private set; }
+
+        public LockFileLibrary LockFileLibrary { get; private set; }
 
         public IPackage Package
         {
@@ -36,13 +37,13 @@ namespace NuGet
                 if (_package == null)
                 {
                     var nuspecPath = Path.Combine(_versionDir, string.Format("{0}.nuspec", Id));
-                    if (_lockFileLibrary == null)
+                    if (LockFileLibrary == null)
                     {
                         _package = new UnzippedPackage(_repositoryRoot, nuspecPath);
                     }
                     else
                     {
-                        _package = new LockFilePackage(_repositoryRoot, nuspecPath, _lockFileLibrary);
+                        _package = new LockFilePackage(_repositoryRoot, nuspecPath, LockFileLibrary);
                     }
                 }
 

--- a/test/Microsoft.Framework.PackageManager.FunctionalTests/KpmBundleTests.cs
+++ b/test/Microsoft.Framework.PackageManager.FunctionalTests/KpmBundleTests.cs
@@ -136,7 +136,6 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   ""webroot"": ""to_be_overridden""
 }")
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
-  ""dependencies"": {},
   ""packages"": ""packages""
 }")
                     .WithFileContents(Path.Combine("wwwroot", "web.config"), outputWebConfigTemplate, testEnv.ProjectName);
@@ -231,7 +230,6 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   ""webroot"": ""../../../wwwroot""
 }")
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
-  ""dependencies"": {},
   ""packages"": ""packages""
 }")
                     .WithFileContents(Path.Combine("wwwroot", "web.config"), outputWebConfigTemplate, testEnv.ProjectName);
@@ -293,7 +291,6 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   ""bundleExclude"": ""Data/Backup/**""
 }")
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
-  ""dependencies"": {},
   ""packages"": ""packages""
 }");
                 Assert.True(expectedOutputDir.MatchDirectoryOnDisk(testEnv.BundleOutputDirPath,
@@ -393,7 +390,6 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   ]
 }")
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
-  ""dependencies"": {},
   ""packages"": ""packages""
 }");
                 Assert.True(expectedOutputDir.MatchDirectoryOnDisk(testEnv.BundleOutputDirPath,
@@ -485,7 +481,6 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   ]
 }")
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
-  ""dependencies"": {},
   ""packages"": ""packages""
 }");
                 Assert.True(expectedOutputDir.MatchDirectoryOnDisk(testEnv.BundleOutputDirPath,
@@ -575,7 +570,6 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
 }")
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
-  ""dependencies"": {},
   ""packages"": ""packages""
 }");
                 Assert.True(expectedOutputDir.MatchDirectoryOnDisk(testEnv.BundleOutputDirPath,
@@ -642,7 +636,6 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
                     .WithFileContents(Path.Combine("approot", "src", testEnv.ProjectName, "project.json"), @"{
 }")
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
-  ""dependencies"": {},
   ""packages"": ""packages""
 }");
                 Assert.True(expectedOutputDir.MatchDirectoryOnDisk(testEnv.BundleOutputDirPath,
@@ -722,7 +715,6 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   ""webroot"": ""../../../wwwroot""
 }")
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
-  ""dependencies"": {},
   ""packages"": ""packages""
 }")
                     .WithFileContents(Path.Combine("wwwroot", "web.config"), outputWebConfigTemplate, testEnv.ProjectName);
@@ -819,7 +811,6 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   ""webroot"": ""../../../wwwroot""
 }")
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
-  ""dependencies"": {},
   ""packages"": ""packages""
 }")
                     .WithFileContents(Path.Combine("wwwroot", "web.config"), outputWebConfigContents, testEnv.ProjectName);
@@ -889,7 +880,6 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   }
 }")
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
-  ""dependencies"": {},
   ""packages"": ""packages""
 }")
                     .WithFileContents("run.cmd", BatchFileTemplate, string.Empty, Constants.BootstrapperExeName, testEnv.ProjectName, "run")
@@ -981,7 +971,6 @@ exec ""{2}{3}"" --appbase ""${0}"" Microsoft.Framework.ApplicationHost {4} ""$@"
   }
 }")
                     .WithFileContents(Path.Combine("approot", "global.json"), @"{
-  ""dependencies"": {},
   ""packages"": ""packages""
 }")
                     .WithFileContents("run.cmd", BatchFileTemplate, batchFileBinPath, Constants.BootstrapperExeName, testEnv.ProjectName, "run")


### PR DESCRIPTION
parent #1133 #1217 . The two parent issues have some overlap, so we make the changes in one PR.

@shhsu , here is the branch you can use for the optimization work. It contains the following changes:

1. `kpm bundle --no-source` add newly generated nupkgs into lockfile.
2. Remove SHAs from `global.json` and put them into lockfile.
3. SHAs are not written to disk after `kpm restore`.