### PR TITLE
Leave package dependencies unresolved when lockfile is missing

### DIFF
--- a/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
+++ b/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
@@ -48,15 +48,24 @@ namespace Microsoft.Framework.Runtime
                 var lockFileFormat = new LockFileFormat();
                 var lockFile = lockFileFormat.Read(projectLockJsonPath);
                 NuGetDependencyProvider.ApplyLockFile(lockFile);
-            }
 
-            DependencyWalker = new DependencyWalker(new IDependencyProvider[] {
-                ProjectDepencyProvider,
-                NuGetDependencyProvider,
-                referenceAssemblyDependencyResolver,
-                gacDependencyResolver,
-                unresolvedDependencyProvider
-            });
+                DependencyWalker = new DependencyWalker(new IDependencyProvider[] {
+                    ProjectDepencyProvider,
+                    NuGetDependencyProvider,
+                    referenceAssemblyDependencyResolver,
+                    gacDependencyResolver,
+                    unresolvedDependencyProvider
+                });
+            }
+            else
+            {
+                DependencyWalker = new DependencyWalker(new IDependencyProvider[] {
+                    ProjectDepencyProvider,
+                    referenceAssemblyDependencyResolver,
+                    gacDependencyResolver,
+                    unresolvedDependencyProvider
+                });
+            }
 
             LibraryExportProvider = new CompositeLibraryExportProvider(new ILibraryExportProvider[] {
                 new ProjectLibraryExportProvider(ProjectResolver, ServiceProvider),

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
@@ -220,12 +220,6 @@ namespace Microsoft.Framework.Runtime
                                           IEnumerable<IPackagePathResolver> cacheResolvers,
                                           PackageInfo packageInfo)
         {
-            if (packageInfo.LockFileLibrary == null)
-            {
-                throw new InvalidOperationException(
-                    string.Format("{0} must be loaded before resolving package path", LockFileFormat.LockFileName));
-            }
-
             string expectedHash = packageInfo.LockFileLibrary.Sha;
 
             foreach (var resolver in cacheResolvers)


### PR DESCRIPTION
Fixing a bug introduced by https://github.com/aspnet/XRE/pull/1260: when lockfiles are missing, VS is frozen after you open the solution.

@davidfowl , leave package dependencies unresolved when lockfile is missing.