### PR TITLE
More performance improvements

### DIFF
--- a/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
+++ b/src/Microsoft.Framework.Runtime/ApplicationHostContext.cs
@@ -80,6 +80,14 @@ namespace Microsoft.Framework.Runtime
             AssemblyLoadContextFactory = loadContextFactory ?? new RuntimeLoadContextFactory(ServiceProvider);
             namedCacheDependencyProvider = namedCacheDependencyProvider ?? NamedCacheDependencyProvider.Empty;
 
+            var projectName = PathUtility.GetDirectoryName(ProjectDirectory);
+
+            Project project;
+            if (ProjectResolver.TryResolveProject(projectName, out project))
+            {
+                Project = project;
+            }
+
             // Default services
             _serviceProvider.Add(typeof(IApplicationEnvironment), new ApplicationEnvironment(Project, targetFramework, configuration));
             _serviceProvider.Add(typeof(IFileWatcher), NoopWatcher.Instance);
@@ -122,18 +130,7 @@ namespace Microsoft.Framework.Runtime
             }
         }
 
-        public Project Project
-        {
-            get
-            {
-                Project project;
-                if (Project.TryGetProject(ProjectDirectory, out project))
-                {
-                    return project;
-                }
-                return null;
-            }
-        }
+        public Project Project { get; private set; }
 
         public IAssemblyLoadContextFactory AssemblyLoadContextFactory { get; private set; }
 

--- a/src/Microsoft.Framework.Runtime/DefaultHost.cs
+++ b/src/Microsoft.Framework.Runtime/DefaultHost.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Framework.Runtime
         public DefaultHost(DefaultHostOptions options,
                            IServiceProvider hostServices)
         {
-            _projectDirectory = Normalize(options.ApplicationBaseDirectory);
+            _projectDirectory = Path.GetFullPath(options.ApplicationBaseDirectory);
             _targetFramework = options.TargetFramework;
 
             Initialize(options, hostServices);
@@ -167,16 +167,6 @@ namespace Microsoft.Framework.Runtime
             }
 
             CallContextServiceLocator.Locator.ServiceProvider = ServiceProvider;
-        }
-
-        private static string Normalize(string projectDir)
-        {
-            if (File.Exists(projectDir))
-            {
-                projectDir = Path.GetDirectoryName(projectDir);
-            }
-
-            return Path.GetFullPath(projectDir.TrimEnd(Path.DirectorySeparatorChar));
         }
     }
 }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/NuGetDependencyResolver.cs
@@ -170,11 +170,11 @@ namespace Microsoft.Framework.Runtime
 
                 // Try to find a contract folder for this package and store that
                 // for compilation
-                string contractPath = Path.Combine(dependency.Path, "lib", "contract",
-                                                   package.Id + ".dll");
-                if (File.Exists(contractPath))
+                string contractPath = Path.Combine("lib", "contract", package.Id + ".dll");
+
+                if (packageInfo.LockFileLibrary.Files.Any(f => f.Path == contractPath))
                 {
-                    packageDescription.ContractPath = contractPath;
+                    packageDescription.ContractPath = Path.Combine(dependency.Path, contractPath);
                 }
 
                 if (Servicing.Breadcrumbs.IsPackageServiceable(packageDescription.Package))
@@ -235,19 +235,6 @@ namespace Microsoft.Framework.Runtime
             }
 
             return defaultResolver.GetInstallPath(packageInfo.Id, packageInfo.Version);
-        }
-
-        private string GetExpectedHash(IPackagePathResolver defaultResolver, IPackage package)
-        {
-            var defaultHashPath = defaultResolver.GetHashPath(package.Id, package.Version);
-            string expectedHash = null;
-
-            if (File.Exists(defaultHashPath))
-            {
-                expectedHash = File.ReadAllText(defaultHashPath);
-            }
-
-            return expectedHash;
         }
 
         private static IEnumerable<IPackagePathResolver> GetCacheResolvers()

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
@@ -47,14 +47,14 @@ namespace Microsoft.Framework.Runtime
             var version = libraryRange.VersionRange?.MinVersion;
 
             string path;
-            if (!FrameworkResolver.TryGetAssembly(name, targetFramework, out path))
+            Version assemblyVersion;
+
+            if (!FrameworkResolver.TryGetAssembly(name, targetFramework, out path, out assemblyVersion))
             {
                 return null;
             }
 
-            SemanticVersion assemblyVersion = VersionUtility.GetAssemblyVersion(path);
-
-            if (version == null || version == assemblyVersion)
+            if (version == null || version.Version == assemblyVersion)
             {
                 _resolvedPaths[name] = path;
 
@@ -64,7 +64,7 @@ namespace Microsoft.Framework.Runtime
                     Identity = new Library
                     {
                         Name = name,
-                        Version = assemblyVersion,
+                        Version = new SemanticVersion(assemblyVersion),
                         IsGacOrFrameworkReference = true
                     },
                     LoadableAssemblies = new[] { name },
@@ -98,7 +98,9 @@ namespace Microsoft.Framework.Runtime
             //  the specific path for the target framework
 
             string path;
-            if (FrameworkResolver.TryGetAssembly(target.Name, target.TargetFramework, out path))
+            Version version;
+
+            if (FrameworkResolver.TryGetAssembly(target.Name, target.TargetFramework, out path, out version))
             {
                 return new LibraryExport(target.Name, path);
             }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/WalkContext.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/WalkContext.cs
@@ -246,7 +246,7 @@ namespace Microsoft.Framework.Runtime
 
             var queue = new Queue<Tuple<Node, TState>>();
             queue.Enqueue(Tuple.Create(root, state));
-            while (!queue.IsEmpty())
+            while (queue.Count > 0)
             {
                 var work = queue.Dequeue();
                 var innerState = visitor(work.Item1, work.Item2);

--- a/src/Microsoft.Framework.Runtime/IFrameworkReferenceResolver.cs
+++ b/src/Microsoft.Framework.Runtime/IFrameworkReferenceResolver.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Runtime.Versioning;
 
 namespace Microsoft.Framework.Runtime
 {
     public interface IFrameworkReferenceResolver
     {
-        bool TryGetAssembly(string name, FrameworkName frameworkName, out string path);
+        bool TryGetAssembly(string name, FrameworkName frameworkName, out string path, out Version version);
     }
 }

--- a/src/Microsoft.Framework.Runtime/NuGet/Repositories/PackageRepository.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Repositories/PackageRepository.cs
@@ -53,7 +53,8 @@ namespace NuGet
 
         public void ApplyLockFile(LockFile lockFile)
         {
-            _lockFileLibraries = lockFile.Libraries.ToLookup(l => l.Name);
+            var stringComparer = _checkPackageIdCase ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+            _lockFileLibraries = lockFile.Libraries.ToLookup(l => l.Name, stringComparer);
         }
 
         public IEnumerable<PackageInfo> FindPackagesById(string packageId)

--- a/src/Microsoft.Framework.Runtime/ProjectResolver.cs
+++ b/src/Microsoft.Framework.Runtime/ProjectResolver.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Framework.Runtime
             if (_projects.TryGetValue(name, out projectInfo))
             {
                 project = projectInfo.Project;
-                return true;
+                return project != null;
             }
 
             return false;


### PR DESCRIPTION
- Do all project parsing via IProjectResolver
- Cache lookup of lock file libraries
- Get versions from the redist list
- Reduce IO at project lookup time by scanning global paths up front
- Use lock file to figure out contract path

/cc @shhsu @anurse @ChengTian 